### PR TITLE
Update gunicorn.conf

### DIFF
--- a/conf/supervisor/conf.d/gunicorn.conf
+++ b/conf/supervisor/conf.d/gunicorn.conf
@@ -1,7 +1,7 @@
 [program:gunicorn]
 environment=PATH="/opt/kriek/env-kriek/bin"
-command = /opt/kriek/env-kriek/bin/python /opt/kriek/kriek/manage.py run_gunicorn -w 4 --timeout=300 
-directory =  /opt/kriek/kriek/
+command = /opt/kriek/env-kriek/bin/gunicorn kriek.wsgi:application -w 4 --timeout=300 --bind 127.0.0.1:8000
+directory = /opt/kriek/kriek/
 user = pi
 autostart = true
 autorestart = true


### PR DESCRIPTION
I changed the command to avoid the error message in gunicorn_err.log (see below).
I changed it according to this example: http://agiliq.com/blog/2014/05/supervisor-with-django-and-gunicorn/

===================================================0
gunicorn_err.log:
!!!
!!! WARNING: This command is deprecated.
!!!
!!!         You should now run your application with the WSGI interface
!!!         installed with your project. Ex.:
!!!
!!!             gunicorn myproject.wsgi:application
!!!
!!!         See https://docs.djangoproject.com/en/1.5/howto/deployment/wsgi/gunicorn/
!!!         for more info.
!!!
